### PR TITLE
open top level Explore by default

### DIFF
--- a/quartz/quartz/components/ExplorerNode.tsx
+++ b/quartz/quartz/components/ExplorerNode.tsx
@@ -126,13 +126,15 @@ export class FileNode {
    * @param collapsed default state of folders (collapsed by default or not)
    * @returns array containing folder state for tree
    */
-  getFolderPaths(collapsed: boolean): FolderState[] {
+  getFolderPaths(collapseSubFolders: boolean): FolderState[] {
     const folderPaths: FolderState[] = []
 
     const traverse = (node: FileNode, currentPath: string) => {
       if (!node.file) {
         const folderPath = joinSegments(currentPath, node.name)
         if (folderPath !== "") {
+          // If the folder is at the top level, open it by default
+          const collapsed = node.depth === 1 ? false : collapseSubFolders
           folderPaths.push({ path: folderPath, collapsed })
         }
 


### PR DESCRIPTION
<img width="317" alt="Screenshot 2024-10-23 at 16 05 31" src="https://github.com/user-attachments/assets/cd3483c0-dd60-4abc-a48e-05b50db72b08">
