### PR TITLE
Document SDK v0.7.0 changes

### DIFF
--- a/Explore/PubkyCore/API.md
+++ b/Explore/PubkyCore/API.md
@@ -434,32 +434,10 @@ All errors follow a consistent format:
 
 ## Best Practices
 
-### Efficient List Operations
-
-**Paginate large datasets:**
-```javascript
-async function getAllPosts(client, publicKey) {
-    const allPosts = [];
-    let cursor = null;
-    
-    do {
-        const response = await client.list(
-            `pubky://${publicKey}/pub/myapp/posts/`,
-            { limit: 100, cursor }
-        );
-        
-        allPosts.push(...response.entries);
-        cursor = response.cursor;
-    } while (response.has_more);
-    
-    return allPosts;
-}
-```
-
 ### Optimize Storage
 
 **Store structured data efficiently:**
-```javascript
+```
 // Good: Separate entries for each post
 PUT /pub/myapp/posts/001  (small JSON)
 PUT /pub/myapp/posts/002  (small JSON)
@@ -469,18 +447,16 @@ PUT /pub/myapp/posts/003  (small JSON)
 PUT /pub/myapp/all_posts  (large JSON array)
 ```
 
-### Handle Errors Gracefully
+### Handle Rate Limits
 
 ```javascript
-async function robustPut(client, path, data) {
-    const maxRetries = 3;
-    
-    for (let i = 0; i < maxRetries; i++) {
+async function putWithRetry(session, path, data, retries = 3) {
+    for (let i = 0; i < retries; i++) {
         try {
-            return await client.put(path, data);
+            return await session.storage.putText(path, data);
         } catch (error) {
-            if (error.code === 'rate_limit_exceeded') {
-                await sleep(error.retryAfter * 1000);
+            if (error.status === 429) {
+                await new Promise(r => setTimeout(r, 1000 * (i + 1)));
                 continue;
             }
             throw error;

--- a/Explore/PubkyCore/API.md
+++ b/Explore/PubkyCore/API.md
@@ -455,7 +455,7 @@ async function putWithRetry(session, path, data, retries = 3) {
         try {
             return await session.storage.putText(path, data);
         } catch (error) {
-            if (error.status === 429) {
+            if (error.status === 429) { // Too Many Requests
                 await new Promise(r => setTimeout(r, 1000 * (i + 1)));
                 continue;
             }

--- a/Explore/PubkyCore/API.md
+++ b/Explore/PubkyCore/API.md
@@ -246,30 +246,60 @@ When a request is made:
 3. Verify operation is allowed
 4. Execute or deny request
 
-## Event Streaming (Future)
+## Event Streaming
 
-Subscribe to real-time updates on data changes.
+Subscribe to real-time updates on data changes via Server-Sent Events (SSE). Two endpoints serve different use cases:
+
+### GET /events-stream — Real-Time SSE Stream
+
+The primary event API. Clients subscribe to specific users on a homeserver without processing unwanted traffic.
 
 **Request:**
 ```http
-GET /events?paths=/pub/myapp/&since=1704067200
-Authorization: Bearer session_abc123...
+GET /events-stream?user=<z32_pubkey>&user=<z32_pubkey>:<cursor>&limit=100&live=true&path=/pub/
 ```
+
+**Query Parameters:**
+- `user` (required, repeatable): User public key in z32 format. Append `:<cursor>` to resume from a position (e.g. `user=abc123:42`). Up to 50 users per request
+- `limit` (optional): Maximum events before closing (1–65535). Without limit and `live=false`, all historical events are sent then the stream closes
+- `live` (optional): When `true`, delivers all historical events first, then streams new events in real-time. Cannot combine with `reverse`
+- `reverse` (optional): When `true`, delivers events newest-first then closes. Cannot combine with `live`
+- `path` (optional): Filter events by path prefix (e.g. `/pub/pubky.app/`)
 
 **Response (Server-Sent Events):**
 ```http
 HTTP/1.1 200 OK
 Content-Type: text/event-stream
 
-event: created
-data: {"path":"/pub/myapp/posts/003","size":256,"timestamp":1704067400}
+event: PUT
+data: pubky://o1gg96ewuojmopcjbz8895478wdtxtzzuxnfjjz8o8e77csa1ngo/pub/posts/003
+data: cursor: 42
+data: content_hash: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=
 
-event: updated
-data: {"path":"/pub/myapp/profile","size":512,"timestamp":1704067500}
-
-event: deleted
-data: {"path":"/pub/myapp/temp","timestamp":1704067600}
+event: DEL
+data: pubky://o1gg96ewuojmopcjbz8895478wdtxtzzuxnfjjz8o8e77csa1ngo/pub/temp
+data: cursor: 43
 ```
+
+**Event Types:**
+- `PUT`: Data was created or updated. Includes a `content_hash` (base64-encoded Blake3 hash)
+- `DEL`: Data was deleted
+
+**SSE Data Format** (one `data:` line per field):
+1. First line: full `pubky://` resource URL
+2. `cursor: <u64>` — event ID for pagination/resumption
+3. `content_hash: <base64>` — 32-byte Blake3 hash (PUT events only)
+
+### GET /events/ — Paginated Event Feed
+
+Paginated feed of all events across all users on the homeserver. Intended for indexers and aggregators like [[Explore/PubkyApp/Backend/PubkyNexus|Pubky Nexus]].
+
+**Request:**
+```http
+GET /events/?cursor=<event_cursor>&limit=1000
+```
+
+Returns up to 1000 events per batch. Use the returned cursor to paginate through the full history.
 
 ## Admin Endpoints
 

--- a/Explore/PubkyCore/API.md
+++ b/Explore/PubkyCore/API.md
@@ -301,6 +301,30 @@ GET /events/?cursor=<event_cursor>&limit=1000
 
 Returns up to 1000 events per batch. Use the returned cursor to paginate through the full history.
 
+## Signup Token Validation
+
+Homeservers that require signup tokens (via [[Homegate]]) expose an endpoint to check token validity.
+
+### GET /signup_tokens/{token}
+
+Check whether a signup token is valid, used, or unknown.
+
+**Response (200 OK):**
+```json
+{
+  "status": "valid",
+  "created_at": "2025-03-18T12:00:00Z"
+}
+```
+
+**Status values:** `valid` (unused), `used` (already redeemed)
+
+**Error Responses:**
+- `400 Bad Request`: Missing or invalid token format, or homeserver does not require signup tokens
+- `404 Not Found`: Token does not exist
+
+**Rate Limiting:** This endpoint is rate-limited to 10 requests per IP per minute by default.
+
 ## Admin Endpoints
 
 Homeserver administrators can access management endpoints:

--- a/Explore/PubkyCore/Authentication.md
+++ b/Explore/PubkyCore/Authentication.md
@@ -20,13 +20,13 @@ Pubky uses decentralized authentication where users control their own cryptograp
 
 ## User Flow with Pubky Ring
 
-Apps display a QR code, the user scans it with [[PubkyRing|Pubky Ring]], reviews permissions, and approves. The [[HTTPRelay|HTTP Relay]] securely forwards the encrypted AuthToken back to the app, which then exchanges it with the [[Homeserver|Homeserver]] for a session.
+Apps display a QR code, the user scans it with [[PubkyRing|Pubky Ring]], reviews permissions, and approves. The [[HTTPRelay|HTTP Relay]] securely forwards the encrypted AuthToken back to the app via the `/inbox` endpoint, which then exchanges it with the [[Homeserver|Homeserver]] for a session. Auth tokens are valid for a 3-minute window to account for clock drift and slow connections.
 
 The full protocol specification is documented in the [pubky-core GitHub repository](https://github.com/pubky/pubky-core/blob/main/docs/AUTH.md).
 
 ## Relay Security
 
-The [[HTTPRelay|HTTP Relay]] encrypts tokens between the authenticator and the requesting app using a shared `client_secret`. The relay itself only sees encrypted blobs and cannot capture valid auth tokens. See [[SecurityModel|Security Model]] for the full trust analysis.
+The [[HTTPRelay|HTTP Relay]] encrypts tokens between the authenticator and the requesting app using a shared `client_secret`. The relay itself only sees encrypted blobs and cannot capture valid auth tokens. Messages are persisted for up to 5 minutes and deleted after retrieval. See [[SecurityModel|Security Model]] for the full trust analysis.
 
 ## Current Limitations
 

--- a/Explore/PubkyCore/Homeserver.md
+++ b/Explore/PubkyCore/Homeserver.md
@@ -76,5 +76,3 @@ let testnet = EphemeralTestnetBuilder::new()
     .build()
     .await?;
 ```
-
-There is also a `Testnet::new_unseeded()` method for creating a testnet without pre-seeded data.

--- a/Explore/PubkyCore/Homeserver.md
+++ b/Explore/PubkyCore/Homeserver.md
@@ -57,3 +57,24 @@ To spin up an ephemeral testnet:
 ```bash
 cargo run -p pubky-testnet
 ```
+
+### Embedded Postgres
+
+Since v0.7.0, the testnet supports an optional embedded Postgres mode via the `embedded-postgres` feature flag. This allows fully self-contained test environments without requiring an external database:
+
+```bash
+cargo run -p pubky-testnet --features embedded-postgres
+```
+
+The examples use embedded Postgres by default. For programmatic use:
+
+```rust
+use pubky_testnet::EphemeralTestnetBuilder;
+
+let testnet = EphemeralTestnetBuilder::new()
+    .with_embedded_postgres()
+    .build()
+    .await?;
+```
+
+There is also a `Testnet::new_unseeded()` method for creating a testnet without pre-seeded data.

--- a/Explore/PubkyCore/Introduction.md
+++ b/Explore/PubkyCore/Introduction.md
@@ -275,11 +275,11 @@ For [Synonym](https://synonym.to/) as lead of this project, the goal is to:
 - ✅ Rust SDK mature
 - ✅ JavaScript/WASM bindings stable
 - ✅ Authentication system complete
+- ✅ Event streaming SDK (SSE-based, single and multi-user)
 - ✅ Multiple persistence backends
 
 **Active Development:**
 - 🚧 Mobile native bindings (iOS/Android)
-- 🚧 Event streaming enhancements
 - 🚧 Replication and mirroring tools
 - 🚧 Privacy features (encrypted data)
 

--- a/Explore/PubkyCore/Introduction.md
+++ b/Explore/PubkyCore/Introduction.md
@@ -149,7 +149,7 @@ import { Pubky, Keypair } from '@synonymdev/pubky';
 const pubky = new Pubky();
 const signer = pubky.signer(Keypair.random());
 
-// Sign up at a homeserver
+// Sign up (pass signup token for gated homeservers, null for open/testnet)
 const session = await signer.signup(homeserverPk, null);
 
 // Store data

--- a/Explore/PubkyCore/Introduction.md
+++ b/Explore/PubkyCore/Introduction.md
@@ -143,22 +143,23 @@ npm install @synonymdev/pubky
 
 **Quick Example (JavaScript):**
 ```javascript
-import { Pubky } from '@synonymdev/pubky';
+import { Pubky, Keypair } from '@synonymdev/pubky';
 
-// Create client
-const pubky = await Pubky.create();
+// Create client and signer
+const pubky = new Pubky();
+const signer = pubky.signer(Keypair.random());
 
-// Sign up (generates keypair)
-const { publicKey, secretKey } = await pubky.signUp();
+// Sign up at a homeserver
+const session = await signer.signup(homeserverPk, null);
 
 // Store data
-await pubky.put(`/pub/myapp/profile`, JSON.stringify({
+await session.storage.putJson("/pub/myapp/profile", {
   name: "Alice",
   bio: "Decentralized and loving it!"
-}));
+});
 
 // Retrieve data
-const profile = await pubky.get(`/pub/myapp/profile`);
+const profile = await session.storage.getJson("/pub/myapp/profile");
 ```
 
 See [[Explore/PubkyCore/SDK|SDK Documentation]] for complete guides.

--- a/Explore/PubkyCore/Introduction.md
+++ b/Explore/PubkyCore/Introduction.md
@@ -281,6 +281,7 @@ For [Synonym](https://synonym.to/) as lead of this project, the goal is to:
 
 **Active Development:**
 - 🚧 Mobile native bindings (iOS/Android)
+- 🚧 [[Explore/Technologies/Paykit|Paykit]] support
 - 🚧 Replication and mirroring tools
 - 🚧 Privacy features (encrypted data)
 

--- a/Explore/PubkyCore/SDK.md
+++ b/Explore/PubkyCore/SDK.md
@@ -123,137 +123,149 @@ Data is organized in a hierarchical namespace:
 
 **Rust:**
 ```rust
-use pubky::PubkyClient;
+use pubky::Pubky;
 
-let client = PubkyClient::new()?;
+let pubky = Pubky::new()?;
 ```
 
 **JavaScript:**
 ```javascript
 import { Pubky } from '@synonymdev/pubky';
 
-const pubky = await Pubky.create();
+const pubky = new Pubky();
 ```
 
-### Sign Up (Generate Identity)
+### Sign Up (Create Account on Homeserver)
 
 **Rust:**
 ```rust
-let keypair = client.signup()?;
-let public_key = keypair.public_key();
-let secret_key = keypair.secret_key();
+use pubky::{Pubky, Keypair, PublicKey};
+
+let pubky = Pubky::new()?;
+let keypair = Keypair::random();
+let homeserver = PublicKey::try_from("8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo").unwrap();
+
+let signer = pubky.signer(keypair);
+let session = signer.signup(&homeserver, None).await?;
 ```
 
 **JavaScript:**
 ```javascript
-const { publicKey, secretKey } = await pubky.signUp();
+const signer = pubky.signer(keypair);
+const session = await signer.signup(homeserverPk, null);
 ```
 
-### Sign In (Load Existing Identity)
+### Sign In (Existing User)
 
 **Rust:**
 ```rust
-let secret_key = SecretKey::from_bytes(&secret_bytes)?;
-client.signin(secret_key)?;
+let signer = pubky.signer(keypair);
+let session = signer.signin().await?;
 ```
 
 **JavaScript:**
 ```javascript
-await pubky.signIn(secretKey);
+const signer = pubky.signer(keypair);
+const session = await signer.signin();
 ```
 
 ### Store Data (PUT)
 
 **Rust:**
 ```rust
-client.put(
+session.storage().put(
     "/pub/myapp/profile",
-    &serde_json::to_vec(&profile)?
+    serde_json::to_string(&profile)?
 ).await?;
 ```
 
 **JavaScript:**
 ```javascript
-await pubky.put(
-    "/pub/myapp/profile",
-    JSON.stringify(profile)
-);
+await session.storage.putJson("/pub/myapp/profile", profile);
 ```
 
 ### Retrieve Data (GET)
 
 **Rust:**
 ```rust
-let data = client.get("/pub/myapp/profile").await?;
-let profile: Profile = serde_json::from_slice(&data)?;
+let resp = session.storage().get("/pub/myapp/profile").await?;
+let text = resp.text().await?;
 ```
 
 **JavaScript:**
 ```javascript
-const data = await pubky.get("/pub/myapp/profile");
-const profile = JSON.parse(data);
+const profile = await session.storage.getJson("/pub/myapp/profile");
 ```
 
 ### Delete Data (DELETE)
 
 **Rust:**
 ```rust
-client.delete("/pub/myapp/profile").await?;
+session.storage().delete("/pub/myapp/profile").await?;
 ```
 
 **JavaScript:**
 ```javascript
-await pubky.delete("/pub/myapp/profile");
+await session.storage.delete("/pub/myapp/profile");
 ```
 
 ### List Data (Pagination)
 
 **Rust:**
 ```rust
-let entries = client.list(
-    "/pub/myapp/posts/",
-    Some(ListOptions {
-        limit: Some(20),
-        cursor: None,
-        reverse: false,
-    })
-).await?;
+let entries = session.storage().list("/pub/myapp/posts/")?
+    .limit(20)
+    .reverse(true)
+    .send()
+    .await?;
 
 for entry in entries {
-    println!("{}: {} bytes", entry.key, entry.size);
+    println!("{}", entry);
 }
 ```
 
 **JavaScript:**
 ```javascript
-const entries = await pubky.list("/pub/myapp/posts/", {
-    limit: 20,
-    reverse: false
-});
+const entries = await session.storage.list("/pub/myapp/posts/", null, false, 20);
 
-for (const entry of entries) {
-    console.log(`${entry.key}: ${entry.size} bytes`);
+for (const url of entries) {
+    console.log(url);
 }
+```
+
+### Public Read (Unauthenticated)
+
+Read another user's public data without a session:
+
+**Rust:**
+```rust
+let resp = pubky.public_storage()
+    .get(format!("{}/pub/myapp/profile", user_public_key))
+    .await?;
+let text = resp.text().await?;
+```
+
+**JavaScript:**
+```javascript
+const text = await pubky.publicStorage
+    .getText(`${userPk}/pub/myapp/profile`);
 ```
 
 ## Authentication Flows
 
 ### Third-Party Authorization
 
-Pubky Core supports OAuth-style authorization for third-party apps:
+Pubky Core supports OAuth-style authorization for third-party apps via the `pubkyauth://` protocol:
 
 ```rust
-// App requests authorization
-let auth_url = client.request_authorization(
-    "https://myapp.com/callback",
-    vec!["read:/pub/", "write:/pub/myapp/"]
-)?;
+use pubky::{Pubky, Capabilities, AuthFlowKind};
 
-// User approves in [[Explore/Technologies/PubkyRing|Pubky Ring]]
-// Callback receives session token
+let pubky = Pubky::new()?;
+let caps = Capabilities::default();
+let flow = pubky.start_auth_flow(&caps, AuthFlowKind::signin())?;
 
-// App uses token for requests
-client.set_session_token(token)?;
+// Display flow.authorization_url() as QR code for Pubky Ring to scan
+let session = flow.await_approval().await?;
 ```
 
 See [[Authentication]] for the full authentication flow.
@@ -423,43 +435,32 @@ const savedProfile = JSON.parse(getRes.value);
 ### Simple Profile Storage
 
 ```javascript
-import { Pubky } from '@synonymdev/pubky';
+import { Pubky, Keypair } from '@synonymdev/pubky';
 
 async function storeProfile() {
-    const pubky = await Pubky.create();
-    
-    // Generate identity
-    const { publicKey, secretKey } = await pubky.signUp();
-    console.log(`Public Key: ${publicKey}`);
-    
-    // Sign in
-    await pubky.signIn(secretKey);
-    
+    const pubky = new Pubky();
+    const keypair = Keypair.random();
+    const signer = pubky.signer(keypair);
+
+    // Sign up at a homeserver
+    const session = await signer.signup(homeserverPk, null);
+    console.log(`Public Key: ${signer.publicKey.z32()}`);
+
     // Store profile (following pubky-app-specs format)
     const profile = {
         name: "Alice",
         bio: "Building on Pubky",
         image: "pubky://user_id/pub/pubky.app/files/0000000000000",
-        links: [
-            {
-                title: "GitHub",
-                url: "https://github.com/alice"
-            }
-        ],
+        links: [{ title: "GitHub", url: "https://github.com/alice" }],
         status: "Exploring decentralized tech."
     };
-    
+
     // Store at standard pubky-app location
-    await pubky.put(
-        "/pub/pubky.app/profile.json",
-        JSON.stringify(profile)
-    );
-    
+    await session.storage.putJson("/pub/pubky.app/profile.json", profile);
     console.log("Profile stored!");
-    
+
     // Retrieve profile
-    const data = await pubky.get("/pub/pubky.app/profile.json");
-    const retrieved = JSON.parse(data);
+    const retrieved = await session.storage.getJson("/pub/pubky.app/profile.json");
     console.log("Retrieved:", retrieved);
 }
 ```
@@ -469,7 +470,7 @@ async function storeProfile() {
 ### Social Feed Application
 
 ```rust
-use pubky::{PubkyClient, ListOptions};
+use pubky::{Pubky, Keypair, PubkySession, PubkyResource};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -479,30 +480,31 @@ struct Post {
     author: String,
 }
 
-async fn publish_post(client: &PubkyClient, post: &Post) -> anyhow::Result<()> {
+async fn publish_post(session: &PubkySession, post: &Post) -> anyhow::Result<()> {
     let post_id = post.timestamp.to_string();
     let path = format!("/pub/social/posts/{}", post_id);
-    
-    client.put(&path, &serde_json::to_vec(post)?).await?;
+
+    session.storage().put(&path, serde_json::to_string(post)?).await?;
     Ok(())
 }
 
-async fn get_feed(client: &PubkyClient, public_key: &str) -> anyhow::Result<Vec<Post>> {
-    let path = format!("pubky://{}/pub/social/posts/", public_key);
-    
-    let entries = client.list(&path, Some(ListOptions {
-        limit: Some(50),
-        reverse: true, // Newest first
-        cursor: None,
-    })).await?;
-    
+async fn get_feed(pubky: &Pubky, public_key: &str) -> anyhow::Result<Vec<Post>> {
+    let path = format!("{}/pub/social/posts/", public_key);
+
+    let entries: Vec<PubkyResource> = pubky.public_storage()
+        .list(path)?
+        .limit(50)
+        .reverse(true)
+        .send()
+        .await?;
+
     let mut posts = Vec::new();
     for entry in entries {
-        let data = client.get(&entry.key).await?;
-        let post: Post = serde_json::from_slice(&data)?;
+        let resp = pubky.public_storage().get(entry.to_string()).await?;
+        let post: Post = serde_json::from_slice(&resp.bytes().await?)?;
         posts.push(post);
     }
-    
+
     Ok(posts)
 }
 ```
@@ -653,42 +655,33 @@ See the [7-events_stream example](https://github.com/pubky/pubky-core/tree/main/
 
 ### Session Management
 
-```rust
-// Create session with capabilities
-let session = client.create_session(vec![
-    "read:/pub/",
-    "write:/pub/myapp/"
-])?;
-
-// Use session token
-client.set_session_token(session.token)?;
-
-// Refresh session
-client.refresh_session().await?;
-```
-
-### Recovery Files
+Sessions are created via the `Signer` and provide scoped storage access:
 
 ```rust
-// Export recovery file (encrypted)
-let recovery_data = client.export_recovery("password")?;
-std::fs::write("recovery.dat", recovery_data)?;
+use pubky::{Pubky, Keypair};
 
-// Import recovery file
-let recovery_data = std::fs::read("recovery.dat")?;
-client.import_recovery(&recovery_data, "password")?;
+let pubky = Pubky::new()?;
+let signer = pubky.signer(Keypair::random());
+
+// Sign in returns a session
+let session = signer.signin().await?;
+
+// Session info
+println!("User: {}", session.info().public_key());
+
+// Sign out invalidates the session
+session.signout().await?;
 ```
 
 ### Multiple Identities
 
 ```rust
-let client1 = PubkyClient::new()?;
-client1.signin(secret_key_1)?;
+let pubky = Pubky::new()?;
 
-let client2 = PubkyClient::new()?;
-client2.signin(secret_key_2)?;
+let session1 = pubky.signer(keypair_1).signin().await?;
+let session2 = pubky.signer(keypair_2).signin().await?;
 
-// Each client maintains separate identity
+// Each session maintains a separate identity
 ```
 
 ## Platform-Specific Notes
@@ -727,12 +720,10 @@ client.put(
 
 **Rust:**
 ```rust
-use pubky::PubkyError;
+use pubky::Error;
 
-match client.get("/pub/myapp/data").await {
-    Ok(data) => println!("Retrieved: {:?}", data),
-    Err(PubkyError::NotFound) => println!("Data not found"),
-    Err(PubkyError::Unauthorized) => println!("Not authorized"),
+match session.storage().get("/pub/myapp/data").await {
+    Ok(resp) => println!("Retrieved: {}", resp.text().await?),
     Err(e) => eprintln!("Error: {}", e),
 }
 ```
@@ -740,16 +731,11 @@ match client.get("/pub/myapp/data").await {
 **JavaScript:**
 ```javascript
 try {
-    const data = await pubky.get("/pub/myapp/data");
-    console.log("Retrieved:", data);
+    const text = await session.storage.getText("/pub/myapp/data");
+    console.log("Retrieved:", text);
 } catch (error) {
-    if (error.code === 'NOT_FOUND') {
-        console.log("Data not found");
-    } else if (error.code === 'UNAUTHORIZED') {
-        console.log("Not authorized");
-    } else {
-        console.error("Error:", error.message);
-    }
+    // error.name: "RequestError", "AuthenticationError", "ValidationError", etc.
+    console.error(`${error.name}: ${error.message}`);
 }
 ```
 

--- a/Explore/PubkyCore/SDK.md
+++ b/Explore/PubkyCore/SDK.md
@@ -527,6 +527,7 @@ The repository includes comprehensive examples:
 - [4-storage](https://github.com/pubky/pubky-core/tree/main/examples/rust/4-storage) - CRUD operations
 - [5-request](https://github.com/pubky/pubky-core/tree/main/examples/rust/5-request) - Authorization
 - [6-auth_flow_signup](https://github.com/pubky/pubky-core/tree/main/examples/rust/6-auth_flow_signup) - Full signup flow
+- [7-events_stream](https://github.com/pubky/pubky-core/tree/main/examples/rust/7-events_stream) - SSE event streaming
 
 ## Testing
 
@@ -570,6 +571,85 @@ cargo test
 ```
 
 ## Advanced Features
+
+### Event Streaming
+
+The SDK provides a builder API for subscribing to real-time homeserver events via SSE. See [[API#Event Streaming]] for the underlying HTTP endpoint.
+
+**Rust — Single user:**
+```rust
+use pubky::{Pubky, PublicKey, EventType};
+use futures_util::StreamExt;
+
+let pubky = Pubky::new()?;
+let user = PublicKey::try_from("o1gg96ewuojmopcjbz8895478wdtxtzzuxnfjjz8o8e77csa1ngo").unwrap();
+
+let mut stream = pubky.event_stream_for_user(&user, None)
+    .live()
+    .subscribe()
+    .await?;
+
+while let Some(result) = stream.next().await {
+    let event = result?;
+    println!("{}: {} (cursor: {})", event.event_type, event.resource, event.cursor);
+}
+```
+
+**Rust — Multiple users on the same homeserver:**
+```rust
+use pubky::{Pubky, PublicKey, EventCursor};
+use futures_util::StreamExt;
+
+let pubky = Pubky::new()?;
+let user1 = PublicKey::try_from("o1gg96ewuojmopcjbz8895478wdtxtzzuxnfjjz8o8e77csa1ngo").unwrap();
+let user2 = PublicKey::try_from("pxnu33x7jtpx9ar1ytsi4yxbp6a5o36gwhffs8zoxmbuptici1jy").unwrap();
+
+let homeserver = pubky.get_homeserver_of(&user1).await.unwrap();
+
+let mut stream = pubky.event_stream_for(&homeserver)
+    .add_users([(&user1, None), (&user2, Some(EventCursor::new(100)))])?
+    .live()
+    .limit(100)
+    .path("/pub/")
+    .subscribe()
+    .await?;
+
+while let Some(result) = stream.next().await {
+    let event = result?;
+    println!("{}: {}", event.event_type, event.resource);
+}
+```
+
+**JavaScript:**
+```javascript
+const user = PublicKey.from("o1gg96ewuojmopcjbz8895478wdtxtzzuxnfjjz8o8e77csa1ngo");
+
+const stream = await pubky.eventStreamForUser(user, null)
+    .live()
+    .subscribe();
+
+for await (const event of stream) {
+    console.log(`${event.eventType}: ${event.resource.path}`);
+    // event.eventType: "PUT" or "DEL"
+    // event.cursor: string (for pagination/resumption)
+    // event.contentHash: base64 string (PUT only) or undefined
+}
+```
+
+**Builder options:**
+- `.live()` — After historical events, keep streaming new events in real-time
+- `.reverse()` — Deliver events newest-first (cannot combine with `live`)
+- `.limit(n)` — Maximum events to receive before closing
+- `.path("/pub/...")` — Filter events by path prefix
+- `.add_users([(pubkey, cursor), ...])` — Subscribe to multiple users (up to 50)
+
+**Key types:**
+- `EventStreamBuilder` — Fluent builder for configuring subscriptions
+- `Event` — A single event with `event_type`, `resource`, and `cursor`
+- `EventCursor` — A `u64` identifier used for resuming streams from a position
+- `EventType` — Either `Put` (with Blake3 `content_hash`) or `Delete`
+
+See the [7-events_stream example](https://github.com/pubky/pubky-core/tree/main/examples/rust/7-events_stream) for a complete CLI tool.
 
 ### Session Management
 

--- a/Explore/PubkyCore/SDK.md
+++ b/Explore/PubkyCore/SDK.md
@@ -137,6 +137,8 @@ const pubky = new Pubky();
 
 ### Sign Up (Create Account on Homeserver)
 
+For gated homeservers, obtain a signup token via [[Homegate]] first. Pass `None`/`null` only for open homeservers or local testnets.
+
 **Rust:**
 ```rust
 use pubky::{Pubky, Keypair, PublicKey};
@@ -146,13 +148,13 @@ let keypair = Keypair::random();
 let homeserver = PublicKey::try_from("8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo").unwrap();
 
 let signer = pubky.signer(keypair);
-let session = signer.signup(&homeserver, None).await?;
+let session = signer.signup(&homeserver, signup_token.as_deref()).await?;
 ```
 
 **JavaScript:**
 ```javascript
 const signer = pubky.signer(keypair);
-const session = await signer.signup(homeserverPk, null);
+const session = await signer.signup(homeserverPk, signupToken);
 ```
 
 ### Sign In (Existing User)
@@ -442,8 +444,8 @@ async function storeProfile() {
     const keypair = Keypair.random();
     const signer = pubky.signer(keypair);
 
-    // Sign up at a homeserver
-    const session = await signer.signup(homeserverPk, null);
+    // Sign up at a homeserver (null token for open/testnet homeservers)
+    const session = await signer.signup(homeserverPk, signupToken);
     console.log(`Public Key: ${signer.publicKey.z32()}`);
 
     // Store profile (following pubky-app-specs format)

--- a/Explore/Technologies/HTTPRelay.md
+++ b/Explore/Technologies/HTTPRelay.md
@@ -2,9 +2,10 @@
 title: "HTTP Relay"
 ---
 
-HTTP relay service for forwarding encrypted AuthTokens during Pubky [[Authentication|authentication]] flows. Implements the [httprelay.io](https://httprelay.io/) link channel specification.
+HTTP relay service for forwarding encrypted AuthTokens during Pubky [[Authentication|authentication]] flows.
 
-- **GitHub**: [`pubky/http-relay`](https://github.com/pubky/http-relay)
+- **GitHub**: [`pubky/pubky-http-relay`](https://github.com/pubky/pubky-http-relay)
+- **Default endpoint**: `https://httprelay.pubky.app/inbox`
 - **License**: MIT
 - **Language**: Rust
 
@@ -19,39 +20,27 @@ The relay solves this by providing a temporary rendezvous point where encrypted 
 
 ## How It Works
 
-1. **App generates a client secret** and subscribes to a relay channel (long-poll GET)
+Since v0.7.0, the relay uses the `/inbox` endpoint (replacing the previous `/link` channel):
+
+1. **App generates a client secret** and starts long-polling the relay inbox channel
 2. **App shows QR code** containing `pubkyauth:///?relay=...&secret=...&caps=...`
 3. **Ring scans QR**, signs AuthToken, encrypts it with `client_secret`
-4. **Ring POSTs** encrypted blob to the relay channel
-5. **Relay forwards** to the waiting app, which decrypts using `client_secret`
+4. **Ring POSTs** encrypted blob to the relay inbox
+5. **App retrieves** the message via long-poll GET, decrypts using `client_secret`, and acknowledges via DELETE
+
+The `/inbox` endpoint persists messages server-side for up to 5 minutes. The producer can verify delivery via `/ack` and `/await` sub-endpoints.
 
 The relay only ever sees encrypted blobs — it cannot capture valid auth tokens.
 
 See the [pubky-core GitHub docs](https://github.com/pubky/pubky-core/blob/main/docs/AUTH.md) for the full protocol spec and [[Authentication]] for an overview.
 
+### Migration from /link to /inbox
+
+The previous `/link` channel used synchronous producer/consumer pairing. The new `/inbox` channel is more reliable and fixes connectivity issues reported by users. The SDK auto-dispatches: if a relay URL ends with `/link`, the old approach is used; otherwise the `/inbox` approach is used.
+
 ## Self-Hosting
 
-The relay is designed to be self-hostable for reduced latency, privacy, and reliability. Use the [`http-relay`](https://github.com/pubky/http-relay) crate as a dependency in your Rust project:
-
-```rust
-#[tokio::main]
-async fn main() {
-    let http_relay = http_relay::HttpRelay::builder()
-        .http_port(15412)
-        .run()
-        .await
-        .unwrap();
-
-    println!(
-        "Running http relay {}",
-        http_relay.local_link_url().as_str()
-    );
-
-    tokio::signal::ctrl_c().await.unwrap();
-
-    http_relay.shutdown().await.unwrap();
-}
-```
+The relay is designed to be self-hostable for reduced latency, privacy, and reliability. Use the [`pubky-http-relay`](https://github.com/pubky/pubky-http-relay) crate as a dependency in your Rust project.
 
 Apps can specify a custom relay URL via the [[SDK]].
 

--- a/Explore/Technologies/PubkyDocker.md
+++ b/Explore/Technologies/PubkyDocker.md
@@ -158,7 +158,7 @@ POSTGRES_DB=homeserver
 NEXT_PUBLIC_HOMESERVER=8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo
 NEXT_PUBLIC_NEXUS=http://localhost:8080
 NEXT_PUBLIC_TESTNET=true
-HTTP_RELAY=http://localhost:15412/link/
+HTTP_RELAY=http://localhost:15412/inbox/
 NEXT_PUBLIC_PKARR_RELAYS=["https://pkarr.pubky.app","https://pkarr.pubky.org"]
 ```
 

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -152,7 +152,7 @@ import { Pubky, Keypair } from '@synonymdev/pubky';
 const pubky = new Pubky();
 const signer = pubky.signer(Keypair.random());
 
-// Sign up at a homeserver
+// Sign up (pass signup token for gated homeservers, null for open/testnet)
 const session = await signer.signup(homeserverPk, null);
 console.log('Your pubky:', signer.publicKey.z32());
 

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -146,32 +146,33 @@ cargo run
 **Quick Example (JavaScript):**
 
 ```javascript
-import { Pubky } from '@synonymdev/pubky';
+import { Pubky, Keypair } from '@synonymdev/pubky';
 
-// Create client
-const pubky = await Pubky.create();
+// Create client and signer
+const pubky = new Pubky();
+const signer = pubky.signer(Keypair.random());
 
-// Generate a new identity (signup)
-const { publicKey, secretKey } = await pubky.signUp();
-console.log('Your pubky:', publicKey);
+// Sign up at a homeserver
+const session = await signer.signup(homeserverPk, null);
+console.log('Your pubky:', signer.publicKey.z32());
 
 // Store data
-await pubky.put('/pub/myapp/profile', JSON.stringify({
+await session.storage.putJson('/pub/myapp/profile', {
   name: "Alice",
   bio: "Building on Pubky!",
   avatar: "https://example.com/avatar.jpg"
-}));
+});
 
 // Retrieve data
-const profile = await pubky.get('/pub/myapp/profile');
-console.log('Profile:', JSON.parse(profile));
+const profile = await session.storage.getJson('/pub/myapp/profile');
+console.log('Profile:', profile);
 
 // List directory
-const files = await pubky.list('/pub/myapp/');
+const files = await session.storage.list('/pub/myapp/');
 console.log('Files:', files);
 
 // Sign out
-await pubky.signOut();
+await session.signout();
 ```
 
 **Key concepts:**

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -126,19 +126,13 @@ See [[Authentication]] for how Pubky authentication works.
 
 2. **Wrong Passphrase**
    - Recovery file passphrase is incorrect
-   - **Solution**: Verify passphrase, use correct one:
-   ```javascript
-   const pubky = await Pubky.fromRecoveryFile(
-     './recovery.file',
-     'correct-passphrase'
-   );
-   ```
+   - **Solution**: Verify passphrase, use correct one
 
 3. **Session Expired**
    - Sessions have TTL (typically 24 hours)
    - **Solution**: Sign in again:
    ```javascript
-   await pubky.signIn();
+   const session = await signer.signin();
    ```
 
 4. **Clock Skew**
@@ -155,14 +149,9 @@ See [[Authentication]] for how Pubky authentication works.
 **Debug Authentication:**
 
 ```javascript
-// Check current session
-const session = await pubky.session();
-console.log('Session valid:', session.valid);
-console.log('Expires:', new Date(session.expiresAt));
-
 // Force re-authentication
-await pubky.signOut();
-await pubky.signIn();
+await session.signout();
+const newSession = await signer.signin();
 ```
 
 ---
@@ -256,11 +245,11 @@ docker compose logs neo4j
    - **Solution**: Use correct path format:
    ```javascript
    // ✅ Correct
-   await pubky.put('/pub/myapp/data.json', data);
-   
-   // ❌ Wrong
-   await pubky.put('data.json', data);
-   await pubky.put('/myapp/data.json', data);
+   await session.storage.putText('/pub/myapp/data.json', data);
+
+   // ❌ Wrong — path must start with /pub/
+   await session.storage.putText('data.json', data);
+   await session.storage.putText('/myapp/data.json', data);
    ```
 
 2. **Data Too Large**
@@ -271,10 +260,10 @@ docker compose logs neo4j
    - Too many requests in short time
    - **Solution**: Implement backoff:
    ```javascript
-   async function putWithRetry(path, data, retries = 3) {
+   async function putWithRetry(session, path, data, retries = 3) {
      for (let i = 0; i < retries; i++) {
        try {
-         return await pubky.put(path, data);
+         return await session.storage.putText(path, data);
        } catch (e) {
          if (e.status === 429) {
            await new Promise(r => setTimeout(r, 1000 * (i + 1)));
@@ -410,11 +399,11 @@ When reporting bugs, include:
 ```markdown
 ## Environment
 - OS: macOS 14.2
-- SDK: @synonymdev/pubky@0.6.0
+- SDK: @synonymdev/pubky@0.7.0
 - Browser: Chrome 120
 
 ## Steps to Reproduce
-1. Call `await pubky.put('/pub/test/file.json', data)`
+1. Call `await session.storage.putText('/pub/test/file.json', data)`
 2. Observe error
 
 ## Error Message

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -265,7 +265,7 @@ docker compose logs neo4j
        try {
          return await session.storage.putText(path, data);
        } catch (e) {
-         if (e.status === 429) {
+         if (e.status === 429) { // Too Many Requests
            await new Promise(r => setTimeout(r, 1000 * (i + 1)));
          } else throw e;
        }


### PR DESCRIPTION
Updates knowledge base for [pubky-core v0.7.0](https://github.com/pubky/pubky-core/releases/tag/v0.7.0):

- Event streaming API and SDK builder (`/events-stream`, `EventStreamBuilder`)
- Auth relay migration from `/link` to `/inbox` endpoint
- New `GET /signup_tokens/{token}` homeserver endpoint with rate limiting
- Embedded Postgres testnet feature
- Update all SDK examples to v0.7.0 API surface (`PubkyClient` → `Pubky`, `Pubky.create()` → `new Pubky()`, signer/session storage pattern)
- Fix old API patterns in Troubleshooting.md, API.md best practices, and Docker config
- Clarify signup token parameter with Homegate link
- Add Paykit to active development list